### PR TITLE
Fixing Multi-After Bug

### DIFF
--- a/src/GreyhamWooHoo.Interceptor.Core.UnitTests/AfterExecutionTests.cs
+++ b/src/GreyhamWooHoo.Interceptor.Core.UnitTests/AfterExecutionTests.cs
@@ -188,6 +188,11 @@ namespace GreyhamWooHoo.Interceptor.Core.UnitTests
             methodAsNoParametersCount.Should().Be(1, because: "this was the method that was explicitly invoked. ");
             methodHasOneParametercount.Should().Be(0, because: "this method was not invoked. ");
 
+            // Act 2
+            proxy.MethodHasOneParameter(10);
+
+            methodHasOneParametercount.Should().Be(1, because: "this method was not invoked this time. ");
+            methodHasOneParametercount.Should().Be(1, because: "this method was invoke this time. ");
         }
     }
 }

--- a/src/GreyhamWooHoo.Interceptor.Core.UnitTests/AfterExecutionTests.cs
+++ b/src/GreyhamWooHoo.Interceptor.Core.UnitTests/AfterExecutionTests.cs
@@ -164,5 +164,30 @@ namespace GreyhamWooHoo.Interceptor.Core.UnitTests
             var theStringParameter = (string)store.Parameters["theString"];
             theStringParameter.Should().Be("woo", because: "that is the value passed in. ");
         }
+
+        [TestMethod]
+        public void WhenInterfaceHasTwoCallbacks_MethodIsCalledOnlyOnce()
+        {
+            // Arrange
+            var methodAsNoParametersCount = 0;
+            var methodHasOneParametercount = 0;
+
+            var proxy = _builder.InterceptAfterExecutionOf(theMethodCalled: nameof(IAfterExecutionTestInterface.MethodAsNoParameters), andCallbackWith: result =>
+            {
+                methodAsNoParametersCount++;
+            })
+            .InterceptAfterExecutionOf(theMethodCalled: nameof(IAfterExecutionTestInterface.MethodHasOneParameter), andCallbackWith: result =>
+            {
+                methodHasOneParametercount++;
+            }).Build();
+
+            // Act 1
+            proxy.MethodAsNoParameters();
+
+            // Assert 1
+            methodAsNoParametersCount.Should().Be(1, because: "this was the method that was explicitly invoked. ");
+            methodHasOneParametercount.Should().Be(0, because: "this method was not invoked. ");
+
+        }
     }
 }

--- a/src/GreyhamWooHoo.Interceptor.Core.UnitTests/BeforeExecutionTests.cs
+++ b/src/GreyhamWooHoo.Interceptor.Core.UnitTests/BeforeExecutionTests.cs
@@ -146,5 +146,35 @@ namespace GreyhamWooHoo.Interceptor.Core.UnitTests
             callback1.Should().BeTrue(because: "the first OnBefore callout will be invoked. ");
             callback2.Should().BeTrue(because: "the second OnBefore callout will be invoked. ");
         }
+
+        [TestMethod]
+        public void WhenInterfaceHasTwoCallbacks_MethodIsCalledOnlyOnce()
+        {
+            // Arrange
+            var methodWithNoParameters = 0;
+            var methodWithOneParameter = 0;
+
+            var proxy = _builder.InterceptBeforeExecutionOf(theMethodNamed: nameof(IBeforeExecutionTestInterface.MethodWithNoParameters), andCallBackWith: result =>
+            {
+                methodWithNoParameters++;
+            })
+            .InterceptBeforeExecutionOf(theMethodNamed: nameof(IBeforeExecutionTestInterface.MethodWithOneParameter), andCallBackWith: result =>
+            {
+                methodWithOneParameter++;
+            }).Build();
+
+            // Act 1
+            proxy.MethodWithNoParameters();
+
+            // Assert 1
+            methodWithNoParameters.Should().Be(1, because: "this was the method that was explicitly invoked. ");
+            methodWithOneParameter.Should().Be(0, because: "this method was not invoked. ");
+
+            // Act 2
+            proxy.MethodWithOneParameter(10);
+
+            methodWithNoParameters.Should().Be(1, because: "this method was not invoked this time. ");
+            methodWithOneParameter.Should().Be(1, because: "this method was invoke this time. ");
+        }
     }
 }

--- a/src/GreyhamWooHoo.Interceptor.Core/GreyhamWooHoo.Interceptor.Core.csproj
+++ b/src/GreyhamWooHoo.Interceptor.Core/GreyhamWooHoo.Interceptor.Core.csproj
@@ -11,7 +11,10 @@
     <PackageProjectUrl>https://github.com/greyhamwoohoo/interface-interceptor-core</PackageProjectUrl>
     <RepositoryUrl>https://github.com/greyhamwoohoo/interface-interceptor-core</RepositoryUrl>
     <PackageTags>Testing;Mocking;Capture;Replay</PackageTags>
-    <PackageReleaseNotes>1.1.3
+    <PackageReleaseNotes>1.1.4
+- Fixed a bug where OnAfter would be called for all After rules, not just the matching one
+
+1.1.3
 - Stub and OnAfter include parameters and arguments for the method call
 - Improved internal code relating to stubbing void methods
 

--- a/src/GreyhamWooHoo.Interceptor.Core/InterceptorProxy.cs
+++ b/src/GreyhamWooHoo.Interceptor.Core/InterceptorProxy.cs
@@ -62,7 +62,8 @@ namespace GreyhamWooHoo.Interceptor.Core
                 }
             }
 
-            _afterExecutionRules.ToList().ForEach(ar =>
+            var afterExecutionRules = _afterExecutionRules.Where(f => f.MethodName == targetMethod.Name);
+            afterExecutionRules.ToList().ForEach(ar =>
             {
                 try
                 {


### PR DESCRIPTION
There was a bug whereby the AfterExecution callback would be invoked for every method that had a handler; not just the one invoked. That has now been addressed. 